### PR TITLE
Change for PHP namespace support

### DIFF
--- a/xsd/ckXsdComplexType.class.php
+++ b/xsd/ckXsdComplexType.class.php
@@ -32,12 +32,16 @@ class ckXsdComplexType extends ckXsdType
    * Creates a new complex type object for the given php class.
    *
    * @param string $name A name of a php class
-   *
+   * @param string $classNamespace Namespace for the PHP class parameter
    * @return ckXsdComplexType The complex type object
    */
-  public static function create($name)
+  public static function create($name, $classNamespace = '')
   {
-    $reflectClass= new ReflectionAnnotatedClass($name);
+    if (empty($classNamespace)) {
+      $reflectClass = new ReflectionAnnotatedClass($name);
+    } else {
+      $reflectClass = new ReflectionAnnotatedClass($classNamespace . '\\' . $name);
+    }
     $result = new ckXsdComplexType($name, ckXsdNamespace::get('tns'));
 
     ckXsdType::set($name, $result);

--- a/xsd/ckXsdType.class.php
+++ b/xsd/ckXsdType.class.php
@@ -52,7 +52,15 @@ abstract class ckXsdType implements ckDOMSerializable
     }
     else if(class_exists($typeName, true))
     {
-      return self::set($typeName, ckXsdComplexType::create($typeName));
+      if(strpos($typeName, '\\') !== FALSE){
+        $namespaceAndClass = explode('\\', $typeName);
+        $class = end($namespaceAndClass);
+        $namespace = implode('\\', array_splice($namespaceAndClass, 0, -1));
+        return self::set($class, ckXsdComplexType::create($class, $namespace));
+      }
+      else{
+          return self::set($typeName, ckXsdComplexType::create($typeName));
+      }
     }
     else
     {


### PR DESCRIPTION
Hallo, 
Hi, I'm using your class to generate the wsdl for my project.
I'm using PHP5.3 therefore use namespace.
The class that implements the webservice, have the following notation:

```
/**
 * Return the list of Georreferencias
 *
 * @WSMethod(name='getAll', webservice='GeorreferenciaServices')
 * @return Sectorial\\Model\\Entities\\Georreferencia[] array of Georreferencias
 */
public function getAll()
{ ......................... }
```

As your classes do not use namespace, I made a correction of 2 files and I'd like you to tell me what you think, and if you can add to your project.

Thank you very much, goodbye.
Facundo Panizza.
From Argentina.
